### PR TITLE
Add soft delete image api endpoint

### DIFF
--- a/common/dtos/images.go
+++ b/common/dtos/images.go
@@ -36,6 +36,11 @@ type QueryImageRequest struct {
 	ExternalID string `form:"externalID" json:"externalID" validate:"required"`
 }
 
+type DeleteImageRequest struct {
+	UserID   string `form:"userID" json:"userID" validate:"required"`
+	Checksum string `form:"checksum" json:"checksum" validate:"required"`
+}
+
 type ImageDTO struct {
 	browsePrefix string
 }

--- a/common/models/image.go
+++ b/common/models/image.go
@@ -43,6 +43,7 @@ type Image struct {
 	UpdateTime        time.Time   `description:"update time"`
 	Publish           bool        `description:"publish image to third party storage"`
 	ExternalComponent string      `description:"eg. omni-manager , ....."`
+	Deleted           bool        `description:"whether image has been deleted"`
 }
 
 func (Image) TableName() string {

--- a/config/dev.app.toml
+++ b/config/dev.app.toml
@@ -19,10 +19,10 @@ syncInterval = 30
         bucket = "omni-images-test"
         partSize = 419430400
 [persistentStore]
-host = "192.168.1.193"
+host = "127.0.0.1"
 user = "root"
-password = "rootpswd"
+password = "password"
 dbname = "omni_repository"
 port = "3306"
 [mq]
-kafka_brokers = "192.168.1.193:9092"
+kafka_brokers = ""

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -16,6 +16,45 @@ const docTemplate = `{
     "host": "{{.Host}}",
     "basePath": "{{.BasePath}}",
     "paths": {
+        "/delete": {
+            "post": {
+                "description": "deletes an image by user ID and checksum",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Image"
+                ],
+                "summary": "delete an image by user ID and checksum",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "userID",
+                        "name": "userID",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "checksum",
+                        "name": "checksum",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.Image"
+                        }
+                    }
+                }
+            }
+        },
         "/load": {
             "post": {
                 "description": "create a image with specified parameter, image will be downloaded via source url",
@@ -128,7 +167,6 @@ const docTemplate = `{
                 "externalID",
                 "fileName",
                 "name",
-                "publish",
                 "userID"
             ],
             "properties": {
@@ -182,6 +220,9 @@ const docTemplate = `{
                 },
                 "createTime": {
                     "type": "string"
+                },
+                "deleted": {
+                    "type": "boolean"
                 },
                 "desc": {
                     "type": "string"

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -4,6 +4,45 @@
         "contact": {}
     },
     "paths": {
+        "/delete": {
+            "post": {
+                "description": "deletes an image by user ID and checksum",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Image"
+                ],
+                "summary": "delete an image by user ID and checksum",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "userID",
+                        "name": "userID",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "checksum",
+                        "name": "checksum",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.Image"
+                        }
+                    }
+                }
+            }
+        },
         "/load": {
             "post": {
                 "description": "create a image with specified parameter, image will be downloaded via source url",
@@ -116,7 +155,6 @@
                 "externalID",
                 "fileName",
                 "name",
-                "publish",
                 "userID"
             ],
             "properties": {
@@ -170,6 +208,9 @@
                 },
                 "createTime": {
                     "type": "string"
+                },
+                "deleted": {
+                    "type": "boolean"
                 },
                 "desc": {
                     "type": "string"

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -32,7 +32,6 @@ definitions:
     - externalID
     - fileName
     - name
-    - publish
     - userID
     type: object
   models.Image:
@@ -45,6 +44,8 @@ definitions:
         type: string
       createTime:
         type: string
+      deleted:
+        type: boolean
       desc:
         type: string
       externalComponent:
@@ -75,6 +76,32 @@ definitions:
 info:
   contact: {}
 paths:
+  /delete:
+    post:
+      consumes:
+      - application/json
+      description: deletes an image by user ID and checksum
+      parameters:
+      - description: userID
+        in: query
+        name: userID
+        required: true
+        type: string
+      - description: checksum
+        in: query
+        name: checksum
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/models.Image'
+      summary: delete an image by user ID and checksum
+      tags:
+      - Image
   /load:
     post:
       consumes:


### PR DESCRIPTION
1. 支持软删除images[DELETE /path?userID=xxxx&checksum=xxxxxx]
2. 后续PR补充images软删除后的清理行为。
3. 只通过内部端口暴露